### PR TITLE
Add s1c filter for stack generation

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,11 +3,6 @@ name: Static Analysis (Flake8/Ruff)
 on: push
 
 jobs:
-  call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.11.1
-    with:
-      local_package_names: s1_frame_enumerator
-
   call-secrets-analysis-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.11.1
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
-name: Test
+name: Pytest 
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -15,19 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
+      fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: mamba-org/provision-with-micromamba@main
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          environment-name: s1-frame-enumerator
+          environment-name: dist-s1-env
           environment-file: environment.yml
-          extra-specs: |
+          create-args: >-
             python=${{ matrix.python-version }}
+
+      - name: Install package
+        shell: bash -l {0}
+        run: |
+          python -m pip install --no-deps .
+
       - name: Pytest in conda environment
         shell: bash -l {0}
         run: |
-          python -m pip install .
           pytest .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 * Sentinel-1C filtering based on Calibration Date: https://sentinels.copernicus.eu/-/sentinel-1c-products-are-now-calibrated
+* Python 3.13 support.
 
 ### Fixed
 * Conda Environment.yml
 * Natural earth world is no longer within geopandas so linked to github url.
-* Unit tests to latest micromamba.
+* Unit tests now use the latest micromamba action (previous was not supported).
 
 ## [0.0.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,6 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.3]
-
-### Changed
-* Updated to ruff and removed flake8
-
-
-### Added
-* Sentinel-1C filtering based on Calibration Date: https://sentinels.copernicus.eu/-/sentinel-1c-products-are-now-calibrated
-* Python 3.13 support.
-
-### Fixed
-* Conda Environment.yml
-* Natural earth world is no longer within geopandas so linked to github url.
-* Unit tests now use the latest micromamba action (previous was not supported).
-
 ## [0.0.2]
 
 ### Added
@@ -30,13 +15,23 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Linting of packaging files
 * Docstrings in `stack.py`
 * Updated readme with definitions
+* Sentinel-1C filtering based on Calibration Date: https://sentinels.copernicus.eu/-/sentinel-1c-products-are-now-calibrated
+* Python 3.13 support.
 
 ### Fixed
 * Ensure SLCs are contiguous (in addition to frames)
 * Future warning related to pandas `grouper`
+* The syntax within Environment.yml (also added ruff)
+* Natural earth world is no longer within geopandas so linked to github url.
+* Unit tests now use the latest micromamba action (previous was not supported).
+
+### Changed
+* Ruff is now linter
 
 ### Removed
 * Removes min version on asf_search. 
+* Flake8 linting in favor of ruff
+
 
 ## [0.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.0.3]
+
+### Added
+* Sentinel-1C filtering based on Calibration Date: https://sentinels.copernicus.eu/-/sentinel-1c-products-are-now-calibrated
+
+### Fixed
+* Conda Environment.yml
+* Natural earth world is no longer within geopandas so linked to github url.
+
 ## [0.0.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.0.3]
 
+### Changed
+* Updated to ruff and removed flake8
+
+
 ### Added
 * Sentinel-1C filtering based on Calibration Date: https://sentinels.copernicus.eu/-/sentinel-1c-products-are-now-calibrated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 * Conda Environment.yml
 * Natural earth world is no longer within geopandas so linked to github url.
+* Unit tests to latest micromamba.
 
 ## [0.0.2]
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: s1-frame-enumerator
 channels:
   - conda-forge
 dependencies:
-  - python=>3.11 # required for shapely 2.0.0
+  - python>=3.11 # required for shapely 2.0.0
   - pip
   # For packaging, and testing
   - flake8
@@ -24,7 +24,7 @@ dependencies:
   # gis
   - rasterio
   - geopandas
-  - shapely=>2.0
+  - shapely>=2.0
   - pandas
   - tqdm
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,6 @@ dependencies:
   - python>=3.11 # required for shapely 2.0.0
   - pip
   # For packaging, and testing
-  - flake8
-  - flake8-import-order
-  - flake8-blind-except
-  - flake8-builtins
   - ipympl
   - setuptools
   - setuptools_scm
@@ -31,3 +27,4 @@ dependencies:
   - rasterio
   - asf_search
   - hyp3_sdk
+  - ruff

--- a/notebooks/Submitting_to_Hyp3.ipynb
+++ b/notebooks/Submitting_to_Hyp3.ipynb
@@ -351,7 +351,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/0p/d5x2m4tx5kg1246bplsvyfyh0000gq/T/ipykernel_27208/2968930518.py:2: FutureWarning: The geopandas.dataset module is deprecated and will be removed in GeoPandas 1.0. You can get the original 'naturalearth_lowres' data from https://www.naturalearthdata.com/downloads/110m-cultural-vectors/.\n",
+      "/var/folders/0p/d5x2m4tx5kg1246bplsvyfyh0000gq/T/ipykernel_17320/2968930518.py:2: FutureWarning: The geopandas.dataset module is deprecated and will be removed in GeoPandas 1.0. You can get the original 'naturalearth_lowres' data from https://www.naturalearthdata.com/downloads/110m-cultural-vectors/.\n",
       "  df_world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))\n"
      ]
     },
@@ -407,7 +407,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/0p/d5x2m4tx5kg1246bplsvyfyh0000gq/T/ipykernel_27208/1923061845.py:2: FutureWarning: The geopandas.dataset module is deprecated and will be removed in GeoPandas 1.0. You can get the original 'naturalearth_lowres' data from https://www.naturalearthdata.com/downloads/110m-cultural-vectors/.\n",
+      "/var/folders/0p/d5x2m4tx5kg1246bplsvyfyh0000gq/T/ipykernel_17320/1923061845.py:2: FutureWarning: The geopandas.dataset module is deprecated and will be removed in GeoPandas 1.0. You can get the original 'naturalearth_lowres' data from https://www.naturalearthdata.com/downloads/110m-cultural-vectors/.\n",
       "  df_world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))\n"
      ]
     },
@@ -481,7 +481,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Downloading stack from 5 fr\n"
+      "Downloading stack from 5 frame geometries: 100%|█| 5/5 [00:13<00:00,  2.61s/\n"
      ]
     },
     {
@@ -888,7 +888,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Date Pairs: 100%|█| 5/5 [00\n"
+      "Date Pairs: 100%|█████████████████████████████| 5/5 [00:00<00:00, 43.82it/s]\n"
      ]
     }
    ],
@@ -1001,7 +1001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 19,
    "id": "dcc5809e",
    "metadata": {
     "ExecuteTime": {
@@ -1016,7 +1016,7 @@
        "'JOB_NAME: Saudi-Arabia_72_0830'"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1032,7 +1032,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 20,
    "id": "f1cc16df",
    "metadata": {
     "ExecuteTime": {
@@ -1047,7 +1047,7 @@
        "'JOB_NAME character length: 20'"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1058,7 +1058,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 21,
    "id": "2ce9417f",
    "metadata": {
     "ExecuteTime": {
@@ -1073,7 +1073,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 22,
    "id": "7eba165c",
    "metadata": {
     "ExecuteTime": {
@@ -1097,7 +1097,7 @@
        "  'frame_id': 11106}]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1114,7 +1114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 23,
    "id": "cd79c8c2",
    "metadata": {
     "ExecuteTime": {
@@ -1142,7 +1142,7 @@
        "   'frame_id': 11106}}]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1159,7 +1159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 24,
    "id": "d6b386cd",
    "metadata": {
     "ExecuteTime": {
@@ -1174,7 +1174,7 @@
        "25"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1193,7 +1193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 28,
    "id": "839b3d9d",
    "metadata": {
     "ExecuteTime": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,23 +61,56 @@ readme = { file = ['README.md'], content-type = 'text/markdown' }
 
 [tool.ruff]
 line-length = 120
-
-# Exclude a variety of commonly ignored directories.
+src = ["src", "tests"]
 exclude = [
-    '.eggs',
-    '.git',
-    '.ipynb_checkpoints',
-    '.mypy_cache',
-    '.pytest_cache',
-    '.ruff_cache',
-    '.vscode',
-    '__pypackages__',
-    '_build',
-    'build',
-    'dist',
-    'site-packages',
+    ".eggs",
+    ".git",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "build",
+    "dist",
+    "site-packages",
+    "notebooks/*",
+    "tests/data/*",
 ]
 indent-width = 4
 
 [tool.ruff.format]
-quote-style = 'single'
+quote-style = "single"
+indent-style = "space"
+
+[tool.ruff.lint]
+select = [
+    "F",   # flake8: https://docs.astral.sh/ruff/rules/#flake8-f
+    "E",   # flake8: https://docs.astral.sh/ruff/rules/#flake8-e
+    "I",   # isort: https://docs.astral.sh/ruff/rules/#isort-i
+    "UP",  # pyupgrade: https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "D",   # pydocstyle: https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "ANN", # annotations: https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    "PTH", # use-pathlib-pth: https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "TRY", # tryceratops
+]
+
+ignore = [
+  "D100",   # Missing docstring in public module
+  "D101",   # Missing docstring in public class
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D104",   # Missing docstring in public package
+  "D105",   # Missing docstring in magic method
+  "D203",   # 1 blank line required before class docstring
+  "D213",   # Multi-line docstring summary should start at the second line
+  "TRY003", # Avoid specifying long messages outside the exception
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.isort]
+case-sensitive = true
+lines-after-imports = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 
 dynamic = ['version', 'readme']
 
 dependencies = [
     'geopandas',
-    'rasterio',
     'pandas',
     'asf_search',
     'tqdm',

--- a/src/s1_frame_enumerator/__init__.py
+++ b/src/s1_frame_enumerator/__init__.py
@@ -10,7 +10,12 @@ from .s1_frames import (
     get_global_s1_frames,
     get_overlapping_s1_frames,
 )
-from .s1_stack import filter_s1_stack_by_geometric_coverage_per_pass, get_s1_stack, query_slc_metadata_over_frame
+from .s1_stack import (
+    filter_s1_stack_by_geometric_coverage_per_pass,
+    get_s1_stack,
+    query_slc_metadata_over_frame,
+    MIN_S1C_DATE,
+)
 from .s1_stack_formatter import format_results_for_sent1_stack
 
 try:
@@ -37,4 +42,5 @@ __all__ = [
     'get_s1_stack',
     'query_slc_metadata_over_frame',
     'S1Frame',
+    'MIN_S1C_DATE',
 ]

--- a/src/s1_frame_enumerator/__init__.py
+++ b/src/s1_frame_enumerator/__init__.py
@@ -11,12 +11,13 @@ from .s1_frames import (
     get_overlapping_s1_frames,
 )
 from .s1_stack import (
+    MIN_S1C_DATE,
     filter_s1_stack_by_geometric_coverage_per_pass,
     get_s1_stack,
     query_slc_metadata_over_frame,
-    MIN_S1C_DATE,
 )
 from .s1_stack_formatter import format_results_for_sent1_stack
+
 
 try:
     __version__ = version(__name__)

--- a/src/s1_frame_enumerator/exceptions.py
+++ b/src/s1_frame_enumerator/exceptions.py
@@ -1,7 +1,10 @@
 class StackFormationError(Exception):
-    """If Generation of a Stack from S1Frames is not well-posed e.g. not in the same
-    track (aka relative orbit number) or S1Frames are not contiguous"""
+    """If Generation of a Stack from S1Frames is not well-posed e.g. not in the same track.
+
+    This is raised when the Stack formation is not well-posed for example not in the same
+    track (aka relative orbit number) or S1Frames are not contiguous.
+    """
 
 
 class InvalidStack(Exception):
-    """When a dataframe is submitted to enumerate and is not in the requisite form"""
+    """When a dataframe is submitted to enumerate and is not in the requisite form."""

--- a/src/s1_frame_enumerator/ifg_enum.py
+++ b/src/s1_frame_enumerator/ifg_enum.py
@@ -28,7 +28,7 @@ def enumerate_dates(
     n_secondary_scenes_per_ref: int = 3,
     n_init_seeds: int = 1,
 ) -> list[tuple]:
-    """Enumerates date pairs
+    """Enumerate date pairs.
 
     Parameters
     ----------

--- a/src/s1_frame_enumerator/ifg_enum.py
+++ b/src/s1_frame_enumerator/ifg_enum.py
@@ -1,6 +1,5 @@
 import datetime
 import warnings
-from typing import List
 
 import geopandas as gpd
 import pandas as pd
@@ -24,11 +23,11 @@ def viable_secondary_date(
 
 
 def enumerate_dates(
-    dates: List[pd.Timestamp],
+    dates: list[pd.Timestamp],
     min_temporal_baseline_days: int,
     n_secondary_scenes_per_ref: int = 3,
     n_init_seeds: int = 1,
-) -> List[tuple]:
+) -> list[tuple]:
     """Enumerates date pairs
 
     Parameters
@@ -127,9 +126,9 @@ def enumerate_gunw_time_series(
     df_stack: gpd.GeoDataFrame,
     min_temporal_baseline_days: int = 0,
     n_secondary_scenes_per_ref: int = 3,
-    frames: List[S1Frame] = None,
+    frames: list[S1Frame] = None,
     n_init_seeds: int = 1,
-) -> List[dict]:
+) -> list[dict]:
     if df_stack.columns.tolist() != S1_COLUMNS:
         raise InvalidStack('The stack dataframe must be generated using get_s1_stack')
 

--- a/src/s1_frame_enumerator/s1_frames.py
+++ b/src/s1_frame_enumerator/s1_frames.py
@@ -41,7 +41,7 @@ def get_geometry_by_id(frame_id: int, geometry_type: str, hemisphere: str = None
         df_frame = df_frame.reset_index(drop=True)
     if df_frame.shape[0] > 1:
         warn(
-            'The frame you requested has multiple geometries associated to it.' 'This is due to the dateline',
+            'The frame you requested has multiple geometries associated to it.This is due to the dateline',
             category=UserWarning,
         )
     if df_frame.shape[0] == 0:
@@ -57,7 +57,7 @@ class S1Frame:
     frame_geometry: Polygon = field(init=False)
     footprint_geometry: Polygon = field(init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         df_frame = get_geometry_by_id(self.frame_id, 'frame', hemisphere=self.hemisphere)
         # Frame Geometry lookup
         self.frame_geometry = df_frame.geometry.iloc[0]
@@ -73,7 +73,7 @@ class S1Frame:
         df_footprint = get_geometry_by_id(self.frame_id, 'footprint', hemisphere=self.hemisphere)
         self.footprint_geometry = df_footprint.geometry.iloc[0]
 
-    def to_gdf(self, use_footprint_geometry: bool = False):
+    def to_gdf(self, use_footprint_geometry: bool = False) -> gpd.GeoDataFrame:
         return frames2gdf([self], use_footprint_geometry=use_footprint_geometry)
 
 
@@ -122,7 +122,7 @@ def gdf2frames(df_frames: gpd.GeoDataFrame) -> list[S1Frame]:
     return [S1Frame(frame_id=r['frame_id'], hemisphere=hemisphere) for r in records]
 
 
-def frames2gdf(s1frames: list[S1Frame], use_footprint_geometry=False) -> gpd.GeoDataFrame:
+def frames2gdf(s1frames: list[S1Frame], use_footprint_geometry: bool = False) -> gpd.GeoDataFrame:
     records = [asdict(frame) for frame in s1frames]
     geometry = [r.pop('frame_geometry') for r in records]
     footprint_geometry = [r.pop('footprint_geometry') for r in records]

--- a/src/s1_frame_enumerator/s1_frames.py
+++ b/src/s1_frame_enumerator/s1_frames.py
@@ -1,13 +1,13 @@
 from dataclasses import asdict, dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import List, Optional
 from warnings import warn
 
 import geopandas as gpd
 import pandas as pd
 from rasterio.crs import CRS
 from shapely.geometry import Polygon
+
 
 FRAMES_DIR = Path(__file__).parent / 'data'
 FRAMES_PATH = (FRAMES_DIR / 's1_frames_latitude_aligned.geojson.zip').resolve()
@@ -50,10 +50,10 @@ def get_geometry_by_id(frame_id: int, geometry_type: str, hemisphere: str = None
 
 
 @dataclass
-class S1Frame(object):
+class S1Frame:
     frame_id: int
-    hemisphere: Optional[str] = None
-    track_numbers: List[int] = field(init=False)
+    hemisphere: str | None = None
+    track_numbers: list[int] = field(init=False)
     frame_geometry: Polygon = field(init=False)
     footprint_geometry: Polygon = field(init=False)
 
@@ -79,7 +79,7 @@ class S1Frame(object):
 
 def get_overlapping_s1_frames(
     geometry: Polygon,
-    track_numbers: List[int] = None,
+    track_numbers: list[int] = None,
 ) -> gpd.GeoDataFrame:
     df_s1_frames = get_global_s1_frames()
     # Note that intersection across frames near dateline will be correct as geometries are separated
@@ -109,7 +109,7 @@ def get_overlapping_s1_frames(
     return frames
 
 
-def gdf2frames(df_frames: gpd.GeoDataFrame) -> List[S1Frame]:
+def gdf2frames(df_frames: gpd.GeoDataFrame) -> list[S1Frame]:
     xmin, _, xmax, _ = df_frames.total_bounds
     hemisphere = None
     if xmax - xmin > 180:
@@ -122,7 +122,7 @@ def gdf2frames(df_frames: gpd.GeoDataFrame) -> List[S1Frame]:
     return [S1Frame(frame_id=r['frame_id'], hemisphere=hemisphere) for r in records]
 
 
-def frames2gdf(s1frames: List[S1Frame], use_footprint_geometry=False) -> gpd.GeoDataFrame:
+def frames2gdf(s1frames: list[S1Frame], use_footprint_geometry=False) -> gpd.GeoDataFrame:
     records = [asdict(frame) for frame in s1frames]
     geometry = [r.pop('frame_geometry') for r in records]
     footprint_geometry = [r.pop('footprint_geometry') for r in records]

--- a/src/s1_frame_enumerator/s1_stack.py
+++ b/src/s1_frame_enumerator/s1_stack.py
@@ -1,6 +1,5 @@
 import datetime
 import warnings
-from typing import List
 from warnings import warn
 
 import asf_search as asf
@@ -10,10 +9,10 @@ from asf_search import ASFSearchResults
 from shapely.ops import unary_union
 from tqdm import tqdm
 
-
 from .exceptions import StackFormationError
 from .s1_frames import S1Frame
 from .s1_stack_formatter import format_results_for_sent1_stack
+
 
 MINIMUM_PER_FRAME_RATIO = 0.20
 MIN_S1C_DATE = pd.Timestamp(
@@ -24,7 +23,7 @@ MIN_S1C_DATE = pd.Timestamp(
 def query_slc_metadata_over_frame(
     frame: S1Frame,
     max_results_per_frame: int = 100_000,
-    allowable_polarizations: List[str] = ['VV', 'VV+VH'],
+    allowable_polarizations: list[str] = ['VV', 'VV+VH'],
     start_time: datetime.datetime = None,
     stop_time: datetime.datetime = None,
 ) -> ASFSearchResults:
@@ -44,10 +43,10 @@ def query_slc_metadata_over_frame(
 
 
 def filter_s1_stack_by_geometric_coverage_per_pass(
-    df_stack: gpd.GeoDataFrame, frames: List[S1Frame], minimum_coverage_per_pass_ratio: float = 0.80
+    df_stack: gpd.GeoDataFrame, frames: list[S1Frame], minimum_coverage_per_pass_ratio: float = 0.80
 ) -> gpd.GeoDataFrame:
     """
-    Ensures there is a minimum area coverage over the stack. Also ensures that SLCs within a given pass are connected.
+    Ensure there is a minimum area coverage over the stack. Also ensures that SLCs within a given pass are connected.
 
     Parameters
     ----------
@@ -85,9 +84,9 @@ def filter_s1_stack_by_geometric_coverage_per_pass(
 
 
 def filter_s1_stack_by_geometric_coverage_per_frame(
-    df_stack: gpd.GeoDataFrame, frames: List[S1Frame], minimum_coverage_ratio_per_frame: float = 0.5
+    df_stack: gpd.GeoDataFrame, frames: list[S1Frame], minimum_coverage_ratio_per_frame: float = 0.5
 ) -> gpd.GeoDataFrame:
-    """Filters passes that contain a *single* frame that does not contain enough coverage.
+    """Filter stack by geometric coverage per frame.
 
     Parameters
     ----------
@@ -123,7 +122,7 @@ def filter_s1_stack_by_geometric_coverage_per_frame(
 
 
 def filter_s1c_data(df_stack: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
-    """Filters out S1C data from the stack."""
+    """Filter out S1C data from the stack."""
     s1c_filter = (df_stack['slc_id'].map(lambda id_: id_[:3] == 'S1C')) & (
         pd.to_datetime(df_stack['start_time'], utc=True) >= MIN_S1C_DATE
     )
@@ -133,16 +132,19 @@ def filter_s1c_data(df_stack: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
 
 
 def get_s1_stack(
-    frames: List[S1Frame],
-    allowable_months: List[int] = None,
-    allowable_polarizations: List[str] = ['VV', 'VV+VH'],
+    frames: list[S1Frame],
+    allowable_months: list[int] = None,
+    allowable_polarizations: list[str] = ['VV', 'VV+VH'],
     minimum_coverage_ratio_per_pass: float = 0.80,
     minimum_coverage_ratio_per_frame: float = 0.25,
     max_query_results_per_frame: int = 100_000,
     query_start_time: datetime.datetime = None,
     query_stop_time: datetime.datetime = None,
 ) -> gpd.GeoDataFrame:
-    """A stack is defined to be all the SLCs that constitute a single pass along an ascending/descending
+    """
+    Generate a stack of SLCs from a list of frames.
+
+    A stack is defined to be all the SLCs that constitute a single pass along an ascending/descending
     *contiguous* flight path.
 
     Parameters

--- a/src/s1_frame_enumerator/s1_stack_formatter.py
+++ b/src/s1_frame_enumerator/s1_stack_formatter.py
@@ -1,9 +1,9 @@
-from typing import List
 
 import geopandas as gpd
 import pandas as pd
 from rasterio.crs import CRS
 from shapely.geometry import shape
+
 
 S1_COLUMNS = [
     'slc_id',
@@ -22,7 +22,7 @@ S1_COLUMNS = [
 ]
 
 
-def format_results_for_sent1_stack(geojson_results: List[dict], allowable_months: List[int] = None) -> gpd.GeoDataFrame:
+def format_results_for_sent1_stack(geojson_results: list[dict], allowable_months: list[int] = None) -> gpd.GeoDataFrame:
     geometry = [shape(r['geometry']) for r in geojson_results]
     data = [r['properties'] for r in geojson_results]
 

--- a/src/s1_frame_enumerator/s1_stack_formatter.py
+++ b/src/s1_frame_enumerator/s1_stack_formatter.py
@@ -1,4 +1,3 @@
-
 import geopandas as gpd
 import pandas as pd
 from rasterio.crs import CRS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import geopandas as gpd
@@ -6,30 +7,30 @@ import pytest
 
 
 @pytest.fixture(scope='session')
-def test_data_dir():
+def test_data_dir() -> Path:
     data_dir = Path(__file__).resolve().parent / 'data'
     return data_dir
 
 
 @pytest.fixture(scope='session')
-def asf_results_from_query_by_frame():
+def asf_results_from_query_by_frame() -> Callable[[int], list[dict]]:
     data_dir = Path(__file__).resolve().parent / 'data'
 
-    def query_asf_by_frame(frame_id):
-        return json.load(open(data_dir / f'frame_{frame_id}_asf_results.json'))
+    def query_asf_by_frame(frame_id: int) -> list[dict]:
+        return json.load((data_dir / f'frame_{frame_id}_asf_results.json').open())
 
     return query_asf_by_frame
 
 
 @pytest.fixture(scope='session')
-def sample_stack():
+def sample_stack() -> gpd.GeoDataFrame:
     data_dir = Path(__file__).resolve().parent / 'data'
     df = gpd.read_file(data_dir / 'sample_stack_137.geojson')
     return df
 
 
 @pytest.fixture(scope='session')
-def CA_20210915_resp():
+def CA_20210915_resp() -> dict:
     data_dir = Path(__file__).resolve().parent / 'data'
-    json_data = json.load(open(data_dir / 'CA-subset_2021-09-14_asf_results.json'))
+    json_data = json.load((data_dir / 'CA-subset_2021-09-14_asf_results.json').open())
     return json_data

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -51,7 +51,6 @@ def test_get_overlapping_frames():
 
 def test_gdf2frames_consistency():
     """Ensure invertiblility of frames2gdf and gdf2frames"""
-
     # Hawaii
     aoi_geo = Point(-155.5, 19.5).buffer(1)
     frames_0 = get_overlapping_s1_frames(aoi_geo)

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -15,12 +15,12 @@ from s1_frame_enumerator import (
 from s1_frame_enumerator.s1_frames import get_geometry_by_id
 
 
-def test_frame_initialized_by_id():
+def test_frame_initialized_by_id() -> None:
     frame = S1Frame(9849)
     assert frame.track_numbers == [64]
 
 
-def test_get_overlapping_frames():
+def test_get_overlapping_frames() -> None:
     # Southern California
     aoi_geo = Point(-120, 35).buffer(0.1)
     frames = get_overlapping_s1_frames(aoi_geo)
@@ -49,8 +49,8 @@ def test_get_overlapping_frames():
     assert len(frames) == 1
 
 
-def test_gdf2frames_consistency():
-    """Ensure invertiblility of frames2gdf and gdf2frames"""
+def test_gdf2frames_consistency() -> None:
+    """Ensure invertiblility of frames2gdf and gdf2frames."""
     # Hawaii
     aoi_geo = Point(-155.5, 19.5).buffer(1)
     frames_0 = get_overlapping_s1_frames(aoi_geo)
@@ -63,7 +63,7 @@ def test_gdf2frames_consistency():
     assert df_frames_0.equals(df_frames_1)
 
 
-def test_to_ensure_footprints_contain_frames():
+def test_to_ensure_footprints_contain_frames() -> None:
     df_frames = get_global_s1_frames()
     df_extents = get_global_gunw_footprints()
 
@@ -83,7 +83,7 @@ def test_to_ensure_footprints_contain_frames():
     assert df_extents_subset.geometry.contains(df_frames_subset.geometry.buffer(-0.001)).all()
 
 
-def test_frames_at_dateline():
+def test_frames_at_dateline() -> None:
     # Make sure no warnings are passed
     for frame_id in [22738, 4553]:
         # When no hemisphere is passed, raise a UserWarning
@@ -96,7 +96,7 @@ def test_frames_at_dateline():
                 S1Frame(frame_id, hemisphere=hemisphere)
 
 
-def test_large_frame_extent_error():
+def test_large_frame_extent_error() -> None:
     df_frame_0 = get_geometry_by_id(4553, 'frame', hemisphere='west')
     df_frame_1 = get_geometry_by_id(4553, 'frame', hemisphere='east')
     df_frame_2 = get_geometry_by_id(4554, 'frame', hemisphere='east')
@@ -109,7 +109,7 @@ def test_large_frame_extent_error():
     assert len(gdf2frames(df)) == 2
 
 
-def test_frame_construction_error():
+def test_frame_construction_error() -> None:
     with pytest.raises(ValueError):
         # Frame does not exist
         S1Frame(-1)

--- a/tests/test_ifg_enum.py
+++ b/tests/test_ifg_enum.py
@@ -1,5 +1,6 @@
 import datetime
 
+import geopandas as gpd
 import pandas as pd
 import pytest
 
@@ -9,7 +10,7 @@ from s1_frame_enumerator.ifg_enum import select_ifg_pair_from_stack
 from s1_frame_enumerator.s1_stack_formatter import S1_COLUMNS
 
 
-def test_enum_dates_with_min_baseline():
+def test_enum_dates_with_min_baseline() -> None:
     dates = sorted([datetime.datetime(2020 + i, j, 1) for i in range(2) for j in range(1, 13)])
     date_pairs = enumerate_dates(dates, min_temporal_baseline_days=0, n_secondary_scenes_per_ref=1)
 
@@ -19,7 +20,7 @@ def test_enum_dates_with_min_baseline():
     assert date_pairs_expected == date_pairs_sorted
 
 
-def test_enum_dates_with_31_day_baseline():
+def test_enum_dates_with_31_day_baseline() -> None:
     n_dates = 100
     dates = sorted([datetime.datetime(2021, 1, 1) + datetime.timedelta(days=j) for j in range(n_dates)])
 
@@ -44,7 +45,7 @@ def test_enum_dates_with_31_day_baseline():
         n_pairs_lower_seed = n_pairs
 
 
-def test_enum_dates_with_3_neighbors():
+def test_enum_dates_with_3_neighbors() -> None:
     dates = [datetime.datetime(2021, 1, 1) + datetime.timedelta(days=j) for j in range(5)]
 
     for n_seeds in range(1, 5):
@@ -68,7 +69,7 @@ def test_enum_dates_with_3_neighbors():
         assert date_pairs_expected == date_pairs
 
 
-def test_select_valid_ifg_pairs_using_frame_and_dates(sample_stack):
+def test_select_valid_ifg_pairs_using_frame_and_dates(sample_stack: gpd.GeoDataFrame) -> None:
     frames = [S1Frame(21248), S1Frame(21249)]
 
     ref_date = pd.Timestamp('2022-12-20', tz='UTC')
@@ -86,7 +87,7 @@ def test_select_valid_ifg_pairs_using_frame_and_dates(sample_stack):
     assert len(data['reference']) == 3
 
 
-def test_enum_by_track(sample_stack):
+def test_enum_by_track(sample_stack: gpd.GeoDataFrame) -> None:
     data = enumerate_gunw_time_series(
         sample_stack, min_temporal_baseline_days=0, n_secondary_scenes_per_ref=1, frames=None
     )
@@ -96,7 +97,7 @@ def test_enum_by_track(sample_stack):
     assert len(data) == expected_num_of_ifgs
 
 
-def test_enum_by_frames(sample_stack):
+def test_enum_by_frames(sample_stack: gpd.GeoDataFrame) -> None:
     frames = [S1Frame(21248), S1Frame(21249)]
     data = enumerate_gunw_time_series(
         sample_stack, min_temporal_baseline_days=0, n_secondary_scenes_per_ref=1, frames=frames
@@ -108,6 +109,6 @@ def test_enum_by_frames(sample_stack):
 
 
 @pytest.mark.parametrize('df_stack', [pd.DataFrame({'dummy': list(range(10))}), pd.DataFrame(columns=S1_COLUMNS)])
-def test_invalid_stack(df_stack):
+def test_invalid_stack(df_stack: pd.DataFrame) -> None:
     with pytest.raises(InvalidStack):
         enumerate_gunw_time_series(df_stack, min_temporal_baseline_days=0, n_secondary_scenes_per_ref=1)

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from typing import Any
+
 import pytest
 from shapely.ops import unary_union
 
@@ -11,7 +14,7 @@ from s1_frame_enumerator.s1_stack import (
 from s1_frame_enumerator.s1_stack_formatter import S1_COLUMNS, format_results_for_sent1_stack
 
 
-def test_disconnected_frames_and_same_track():
+def test_disconnected_frames_and_same_track() -> None:
     frame_0 = S1Frame(9846)
     frame_1 = S1Frame(9848)
 
@@ -21,7 +24,7 @@ def test_disconnected_frames_and_same_track():
         get_s1_stack([frame_0, frame_1])
 
 
-def test_different_tracks_and_connected_geometry():
+def test_different_tracks_and_connected_geometry() -> None:
     frame_0 = S1Frame(21249)
     frame_1 = S1Frame(22439)
 
@@ -34,8 +37,10 @@ def test_different_tracks_and_connected_geometry():
         get_s1_stack([frame_0, frame_1])
 
 
-def test_allowable_months(monkeypatch, asf_results_from_query_by_frame):
-    def mock_response(*args, **kwargs):
+def test_allowable_months(
+    monkeypatch: pytest.MonkeyPatch, asf_results_from_query_by_frame: Callable[[int], list[dict]]
+) -> None:
+    def mock_response(*args: Any, **kwargs: Any) -> list[dict]:  # noqa: ANN401
         results_0 = asf_results_from_query_by_frame(9847)
         results_1 = asf_results_from_query_by_frame(9848)
         return results_0 + results_1
@@ -51,8 +56,10 @@ def test_allowable_months(monkeypatch, asf_results_from_query_by_frame):
     assert stack_months.isin([month_num]).all()
 
 
-def test_column_structure(monkeypatch, asf_results_from_query_by_frame):
-    def mock_response(*args, **kwargs):
+def test_column_structure(
+    monkeypatch: pytest.MonkeyPatch, asf_results_from_query_by_frame: Callable[[int], list[dict]]
+) -> None:
+    def mock_response(*args: Any, **kwargs: Any) -> list[dict]:  # noqa: ANN401
         return asf_results_from_query_by_frame(9847)
 
     monkeypatch.setattr(s1_stack, 'query_slc_metadata_over_frame', mock_response)
@@ -61,12 +68,14 @@ def test_column_structure(monkeypatch, asf_results_from_query_by_frame):
     assert df_stack.columns.tolist() == S1_COLUMNS
 
 
-def test_sequential_tracks(monkeypatch, asf_results_from_query_by_frame):
+def test_sequential_tracks(
+    monkeypatch: pytest.MonkeyPatch, asf_results_from_query_by_frame: Callable[[int], list[dict]]
+) -> None:
     frame_0 = S1Frame(13403)
     frame_1 = S1Frame(13404)
     frames = [frame_0, frame_1]
 
-    def mock_response(*args, **kwargs):
+    def mock_response(*args: Any, **kwargs: Any) -> list[dict]:  # noqa: ANN401
         results_0 = asf_results_from_query_by_frame(13403)
         results_1 = asf_results_from_query_by_frame(13404)
         return results_0 + results_1
@@ -78,7 +87,7 @@ def test_sequential_tracks(monkeypatch, asf_results_from_query_by_frame):
     assert track_numbers == [86, 87]
 
 
-def filter_per_pass(CA_20210915_resp):
+def filter_per_pass(CA_20210915_resp: dict) -> None:
     # The resp data for one date for the first 2 frames
     data_json = CA_20210915_resp
     df_resp = format_results_for_sent1_stack(data_json)
@@ -102,7 +111,7 @@ def filter_per_pass(CA_20210915_resp):
     assert df_filter.shape[0] == df_resp.shape[0]
 
 
-def filter_per_frame(CA_20210915_resp):
+def filter_per_frame(CA_20210915_resp: dict) -> None:
     # The resp data for one date for the first 2 frames
     data_json = CA_20210915_resp
     df_resp = format_results_for_sent1_stack(data_json)


### PR DESCRIPTION
The current enumeration pulls in all data from Sentinel-1 (including the latest Sentinel-1C).

However, the new Sentinel-1C data was only calibrated after May 19th: https://sentinels.copernicus.eu/-/sentinel-1c-products-are-now-calibrated - calibrated data is essential for InSAR. We put in an error in the InSAR plugin too, but let's not submit jobs that will error out.

Also, now use ruff, support python 3.13, and just make sure the CI/CD is up-to-date.